### PR TITLE
Fix macOS Build Issue during linking SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ else()
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
     find_package(SDL2 REQUIRED)
     include_directories(${SDL2_INCLUDE_DIRS} src)
+    string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
 endif()
 
 add_executable(SnakeGame src/main.cpp src/game.cpp src/controller.cpp src/renderer.cpp src/snake.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,24 @@ set(CMAKE_CXX_FLAGS, "${CXX_FLAGS}")
 
 project(SDL2Test)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+# Check if the system is macOS and if SDL2 is installed via Homebrew
+if(APPLE AND EXISTS /opt/homebrew/include/SDL2)
+    # Set the path to the installed SDL2 include and library directories for Homebrew
+    set(SDL2_INCLUDE_DIR "/opt/homebrew/include/SDL2")
+    set(SDL2_LIB_DIR "/opt/homebrew/lib")
 
-find_package(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIRS} src)
+    # Include and Link directories for SDL2
+    include_directories(${SDL2_INCLUDE_DIR})
+    link_directories(${SDL2_LIB_DIR})
+
+    # Linking against SDL2 library directly
+    set(SDL2_LIBRARIES "SDL2")
+else()
+    # General version for other systems or different installation paths
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+    find_package(SDL2 REQUIRED)
+    include_directories(${SDL2_INCLUDE_DIRS} src)
+endif()
 
 add_executable(SnakeGame src/main.cpp src/game.cpp src/controller.cpp src/renderer.cpp src/snake.cpp)
-string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
 target_link_libraries(SnakeGame ${SDL2_LIBRARIES})


### PR DESCRIPTION
Description:

This pull request addresses the build issue encountered when compiling the SDL2 project on macOS, specifically for users who have installed SDL2 via Homebrew `brew install sdl2`

fixes #22 

Changes made:
1. Modified CMakeLists.txt to detect if the build is happening on macOS and if SDL2 is installed via Homebrew.
2. Added conditional statements to set the SDL2_INCLUDE_DIR and SDL2_LIB_DIR variables to the appropriate paths used by Homebrew.
3. Adjusted the target_link_libraries command to ensure proper linking against the SDL2 library.

The changes ensure compatibility with the standard SDL2 installation method as well as with Homebrew's path structure, providing a more seamless build experience for macOS users.

Testing:
- The build was tested on macOS with SDL2 installed via Homebrew, confirming that the issue is resolved.
- Ensured that the build process remains unaffected on other operating systems.
